### PR TITLE
Update Airdrop SDK to v1.4.2

### DIFF
--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.6",
       "license": "ISC",
       "dependencies": {
-        "@devrev/ts-adaas": "1.3.0",
+        "@devrev/ts-adaas": "1.4.2",
         "axios": "^1.9.0",
         "dotenv": "^16.0.3",
         "js-jsonl": "^1.1.1",
@@ -1839,13 +1839,13 @@
       }
     },
     "node_modules/@devrev/ts-adaas": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-1.3.0.tgz",
-      "integrity": "sha512-gTUPi61FoClmpGHKcMPNTFeDtSab9eBHDMjw7paA8Bcwdj9F+oILskKMeLXz4Epue8U9WGKUNKpce58SEzuu6A==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-1.4.2.tgz",
+      "integrity": "sha512-kuFpITRDdRozLftsn/uXabj+vqgqNCec0/mnG2FD+M7xFG56i8TWU/1szuALb0p1quVx4IpusTwzZwyDrCP1CA==",
       "license": "ISC",
       "dependencies": {
-        "@devrev/typescript-sdk": "^1.1.54",
-        "axios": "^1.7.9",
+        "@devrev/typescript-sdk": "^1.1.59",
+        "axios": "^1.9.0",
         "axios-retry": "^4.5.0",
         "form-data": "^4.0.1",
         "js-jsonl": "^1.1.1",
@@ -1855,13 +1855,13 @@
       }
     },
     "node_modules/@devrev/typescript-sdk": {
-      "version": "1.1.57",
-      "resolved": "https://registry.npmjs.org/@devrev/typescript-sdk/-/typescript-sdk-1.1.57.tgz",
-      "integrity": "sha512-u/1JOKeK5jUJ6ZZlcInHvIASpQEza8RHO9K6bujz2kVHya/q8Bm3zPlgfH3NahW0kCrsOoHOBphg3UC3AHulWg==",
+      "version": "1.1.60",
+      "resolved": "https://registry.npmjs.org/@devrev/typescript-sdk/-/typescript-sdk-1.1.60.tgz",
+      "integrity": "sha512-pxy/SH3fmYHWwmWQEcgakQqOXzMUa0/cX6LS1zHAi3DurSokArs2DVr5Y05p3nTU4y2Ed+QZRaPOLywtMCaUBQ==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs": "^17.0.22",
-        "axios": "^1.3.6",
+        "axios": "^1.9.0",
         "dotenv": "^16.0.3",
         "protobufjs": "^7.3.0",
         "yargs": "^17.6.2"
@@ -8638,9 +8638,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
-      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/code/package.json
+++ b/code/package.json
@@ -53,7 +53,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@devrev/ts-adaas": "1.3.0",
+    "@devrev/ts-adaas": "1.4.2",
     "axios": "^1.9.0",
     "dotenv": "^16.0.3",
     "js-jsonl": "^1.1.1",

--- a/code/src/functions/extraction/workers/attachments-extraction.ts
+++ b/code/src/functions/extraction/workers/attachments-extraction.ts
@@ -64,7 +64,6 @@ processTask({
     }
   },
   onTimeout: async ({ adapter }) => {
-    await adapter.postState();
     await adapter.emit(ExtractorEventType.ExtractionAttachmentsProgress);
   },
 });

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -22,8 +22,6 @@ functions:
     description: Airdrop extraction function for Todo
   - name: loading
     description: Airdrop loading function for Todo
-  - name: install_initial_domain_mapping
-    description: Function for creating a blueprint and installing the initial domain mapping
 
 # The types of connections that the snap-in supports.
 # If an external system supports OAuth, then you should use that.


### PR DESCRIPTION
# Description
Update the Airdrop SDK library version to v1.4.2.
Remove install_initial_domain_mapping from manifest.yaml and await adapter.postState(); from attachments extraction as they are no longer necessary.

# DevRev issue
`no-work-item`

# Documentation PR
`no-docs`
