### PR TITLE
Bump SDK version to 1.6.0

### DIFF
--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.6",
       "license": "ISC",
       "dependencies": {
-        "@devrev/ts-adaas": "1.5.1",
+        "@devrev/ts-adaas": "1.6.0",
         "@devrev/typescript-sdk": "1.1.63",
         "axios": "^1.9.0",
         "dotenv": "^16.0.3",
@@ -1840,9 +1840,9 @@
       }
     },
     "node_modules/@devrev/ts-adaas": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-1.5.1.tgz",
-      "integrity": "sha512-0s5Xt1BKzgB/LYjqWatfsKuFM3fhvrt2MAbu7Kcq4mK89o8925abMVAuyQ1B6ebCz9cmh/PVNx3Alk/Pd/PXWQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@devrev/ts-adaas/-/ts-adaas-1.6.0.tgz",
+      "integrity": "sha512-Ae6/0ejWsnFeO9N4/jkfsBReQ344WcDSZ7uknt2ly/NlDZCgs0PhGKMXyB6N3q4nysY2TxsB9nLcQ1RpUz6PNg==",
       "license": "ISC",
       "dependencies": {
         "@devrev/typescript-sdk": "^1.1.59",

--- a/code/package.json
+++ b/code/package.json
@@ -53,7 +53,7 @@
     "yargs": "^17.6.2"
   },
   "dependencies": {
-    "@devrev/ts-adaas": "1.5.1",
+    "@devrev/ts-adaas": "1.6.0",
     "@devrev/typescript-sdk": "1.1.63",
     "axios": "^1.9.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
# Description
<!-- 
    A brief description of what the PR does/changes.
    Use active voice and present tense, e.g., This commit fixes ...
-->
Update template to use latest version of ADaaS SDK.

# DevRev issue
<!--
    A DevRev issue link (https://app.devrev.ai/devrev/works/ISS-00000) or `no-work-item`.
    Only dependency updates don't need a work item, all others should have one.
-->
https://app.devrev.ai/devrev/works/ISS-192740

# Documentation PR
<!--
    A link to the PR in fern-api-docs if relevant, otherwise `no-docs`.
    Any new feature should link to a PR in https://github.com/devrev/fern-api-docs.
    Dependency updates or changes to the configuration that are not user-facing do not
    require an update to the documentation.
-->
no-docs