### PR TITLE
Clean up make scripts

### DIFF
--- a/code/scripts/cleanup.sh
+++ b/code/scripts/cleanup.sh
@@ -1,35 +1,33 @@
 #!/usr/bin/env bash
 
-source "$(dirname "$0")"/shared.sh
-
-# shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-PACKAGES="$(devrev snap_in_package list $DR_OPTS)"
+# Get all snap-in packages
+PACKAGES="$(devrev snap_in_package list)"
 if [ -z "$PACKAGES" ]; then
     echo "No snap-in packages found"
     exit 0
 fi
 
+# Get the first snap-in package ID
 PACKAGE_ID="$(jq -csr '.[0].id' <<< "$PACKAGES")"
 if [ -z "$PACKAGE_ID" ]; then
     echo "Failed to get snap-in package ID"
     exit 1
 fi
 
-# shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-VERSIONS="$(devrev snap_in_version list $DR_OPTS --package "$PACKAGE_ID")"
+# Get all snap-in versions for the first package
+VERSIONS="$(devrev snap_in_version list --package "$PACKAGE_ID")"
 if [ -z "$VERSIONS" ]; then
     echo "No snap-in versions found"
 else
-  VERSION_ID="$(jq -csr '.[0].id' <<< "$VERSIONS")"
-  if [ -n "${VERSION_ID}" ]; then
-      echo "Deleting snap-in version ${VERSION_ID}"
+    # Get the first snap-in version ID
+    VERSION_ID="$(jq -csr '.[0].id' <<< "$VERSIONS")"
+    if [ -n "${VERSION_ID}" ]; then
+        echo "Deleting snap-in version ${VERSION_ID}"
 
-      # shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-      devrev snap_in_version delete-one $DR_OPTS "${VERSION_ID}" || exit 1
-  fi
+        devrev snap_in_version delete-one "${VERSION_ID}" || exit 1
+    fi
 fi
 
 echo "Deleting snap-in package ${PACKAGE_ID}"
 
-# shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-devrev snap_in_package delete-one $DR_OPTS "${PACKAGE_ID}"
+devrev snap_in_package delete-one "${PACKAGE_ID}"

--- a/code/scripts/deploy.sh
+++ b/code/scripts/deploy.sh
@@ -2,11 +2,12 @@
 
 echo "Creating Snap-in version..."
 
-# shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-VER_OUTPUT=$(devrev snap_in_version create-one $DR_OPTS \
+# Create a new snap-in version
+VER_OUTPUT=$(devrev snap_in_version create-one \
   --path "." \
   --create-package | tee /dev/tty)
 
+# Filter the output to get the snap-in version ID
 FILTERED_OUTPUT=$(grep "snap_in_version" <<<"$VER_OUTPUT" | grep -o '{.*}')
 
 # Check if DevRev CLI returned an error (error messages contain the field 'message')
@@ -14,20 +15,20 @@ if ! jq '.message' <<<"$FILTERED_OUTPUT" | grep null >/dev/null; then
   exit 1
 fi
 
+# Get the snap-in version ID
 VERSION_ID=$(jq -r '.snap_in_version.id' <<<"$FILTERED_OUTPUT")
 
 echo "Waiting 10 seconds for Snap-in version to be ready..."
 sleep 10
 
+# Wait for the snap-in version to be ready
 while :; do
-  # shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-  VER_OUTPUT2=$(devrev snap_in_version show $DR_OPTS "$VERSION_ID")
+  VER_OUTPUT2=$(devrev snap_in_version show "$VERSION_ID")
   STATE=$(jq -r '.snap_in_version.state' <<<"$VER_OUTPUT2")
   if [[ "$STATE" == "build_failed" ]] || [[ "$STATE" == "deployment_failed" ]]; then
     echo "Snap-in version build/deployment failed: $(jq -r '.snap_in_version.failure_reason' <<<"$VER_OUTPUT2")"
     exit 1
   elif [[ "$STATE" == "ready" ]]; then
-
     break
   else
     echo "Snap-in version's state is $STATE, waiting 10 seconds..."
@@ -37,8 +38,8 @@ done
 
 echo "Creating Snap-in draft..."
 
-# shellcheck disable=SC2086 # $DR_OPTS is intentionally split here
-DRAFT_OUTPUT=$(devrev snap_in draft $DR_OPTS --snap_in_version "$VERSION_ID")
+# Create a new snap-in draft
+DRAFT_OUTPUT=$(devrev snap_in draft --snap_in_version "$VERSION_ID")
 jq <<<"$DRAFT_OUTPUT"
 echo "Snap-in draft created. Please go to the Snap-ins page in the DevRev UI to complete the installation process."
 


### PR DESCRIPTION
# Description
This pull request refactors the `deploy` and `cleanup` scripts for managing snap-in packages and versions. The main change is the removal of sourcing `shared.sh` file, which is no longer in use, and the `$DR_OPTS` variable, which was previously used to pass additional options to the `devrev` CLI commands.

# DevRev issue
https://app.devrev.ai/devrev/works/ISS-203111

# Documentation PR
`no-docs`
