### PR TITLE
Add local memory limitation

### DIFF
--- a/code/.npmrc
+++ b/code/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+node-options=--max-old-space-size=700


### PR DESCRIPTION
# Description
This pull request sets a memory limit for local Node.js processes to 700MB by adding the configuration option to the `.npmrc` file. 

## Connected Issues
https://app.devrev.ai/devrev/works/ISS-141117

## Checklist
- [x] Tests added/updated and ran with `npm run test` OR no tests needed.
- [x] Code formatted and checked with `npm run lint`.
- [x] Added "How to test" section to the description OR this section is not needed.
